### PR TITLE
Match solution file to solution in video

### DIFF
--- a/exercise1-keyboard/scss/_header.scss
+++ b/exercise1-keyboard/scss/_header.scss
@@ -75,7 +75,7 @@
 button.megamenu-navitem {
     background-color: transparent;
     border: none;
-    color: inherit;
+    color: var(--color-accent-mediumdark);
     cursor: pointer;
     display: inline-block;
     font-size: 0.9rem;


### PR DESCRIPTION
Fix exercise 1 solution to match video solution.

On the website, when reading through the solution for Manual Accessibility Testing > Keyboard Testing > Fix Focus and Operability Issues for Keyboard Interactivity > “Update MegaNav Button Styling”, there is some CSS that can be copied and pasted for `button.megamenu-navitem`. In this code snippet, `color` is set to `inherit`, but, in the video solution for this section, `color` isn’t changed (it is left set to `var(--color-accent-mediumdark)`).

By itself, this small discrepancy isn’t an issue. However, a later lesson (Manual Accessibility Testing > Testing with Tools & Browser Extensions > Identify Color Contrast Issues with Color Contrast Analyzer & Chrome DevTools > “Measuring Color Contrast Ratio”) assumes that `color` is still set to `var(--color-accent-mediumdark)` when describing how the Chrome DevTools color picker works. If a user doesn’t watch the video solution from the prior keyboard lesson and only reads that lesson’s text, then their code will not match the setup laid out in the color contrast lesson, which may lead to confusion.

I updated `exercise1-keyboard/scss/_header.scss` to match the video solution for the keyboard lesson. However, that lesson's text on the website also needs to be updated accordingly.